### PR TITLE
sync: add gosec syncer

### DIFF
--- a/syncs/sast/gosec/Dockerfile
+++ b/syncs/sast/gosec/Dockerfile
@@ -1,0 +1,11 @@
+FROM golang:1.20-alpine3.17
+
+# install latest version of psql and jq
+RUN apk upgrade && apk add --no-cache curl postgresql-client jq
+
+# install gosec binary to /usr/local/bin
+# TODO(@riyaz): remove script piping and do manual checksum verification
+RUN curl -sfL https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh -s - -b /usr/local/bin v2.14.0
+
+COPY entrypoint.sh /entrypoint.sh
+ENTRYPOINT [ "/entrypoint.sh" ]

--- a/syncs/sast/gosec/entrypoint.sh
+++ b/syncs/sast/gosec/entrypoint.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env sh
+
+#                                    _        _
+#  _ __ ___   ___ _ __ __ _  ___ ___| |_ __ _| |_
+# | '_ ` _ \ / _ | '__/ _` |/ _ / __| __/ _` | __|
+# | | | | | |  __| | | (_| |  __\__ | || (_| | |_
+# |_| |_| |_|\___|_|  \__, |\___|___/\__\__,_|\__|
+#                     |___/
+#
+# This script uses gosec (https://github.com/securego/gosec) to check
+# Golang source code for any know vulnerability or anti-patterns.
+
+#
+# @author: Riyaz Ali (riyaz@mergestat.com)
+
+/usr/local/bin/gosec -no-fail -fmt json ./... \
+    | jq -rc '.Issues | map(. + { "file": .file | sub("/src"; .file) }) | [env.MERGESTAT_REPO_ID, (. | tostring)] | @csv' \
+    | psql $MERGESTAT_POSTGRES_URL -1 \
+        -c "DELETE FROM public.gosec_repo_scans WHERE repo_id = '$MERGESTAT_REPO_ID'" \
+        -c "\copy public.gosec_repo_scans (repo_id, issues) FROM stdin (FORMAT csv)";


### PR DESCRIPTION
Migrate our existing gosec syncer from [`internal/syncer/gosec_repo_scan.go`](https://github.com/mergestat/mergestat/blob/355595211e8a5a5c12967a3f719def3dc7de7df2/internal/syncer/gosec_repo_scan.go)

Related To: https://github.com/mergestat/internal/issues/143