### PR TITLE
sync: add github issue syncer

### DIFF
--- a/syncs/github/issues/Dockerfile
+++ b/syncs/github/issues/Dockerfile
@@ -1,0 +1,7 @@
+FROM alpine:3.17
+
+# install latest version of git, psql and jq
+RUN apk upgrade && apk add --no-cache git postgresql-client jq github-cli
+
+COPY . .
+ENTRYPOINT [ "/entrypoint.sh" ]

--- a/syncs/github/issues/entrypoint.sh
+++ b/syncs/github/issues/entrypoint.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env sh
+
+#                                    _        _
+#  _ __ ___   ___ _ __ __ _  ___ ___| |_ __ _| |_
+# | '_ ` _ \ / _ | '__/ _` |/ _ / __| __/ _` | __|
+# | | | | | |  __| | | (_| |  __\__ | || (_| | |_
+# |_| |_| |_|\___|_|  \__, |\___|___/\__\__,_|\__|
+#                     |___/
+#
+# This script uses github cli to list all issues from the corresponding Github repository.
+#
+# @author: Riyaz Ali (riyaz@mergestat.com)
+
+GITHUB_TOKEN=$MERGESTAT_AUTH_TOKEN gh api graphql --paginate -F owner='{owner}' -F repo='{repo}' -q '.data.repository.issues.nodes' -F query=@/query.gql \
+  | jq -r '.[] | . + ({ "all_labels": [.labels.nodes[].name] | tostring })' \
+  | jq -rc '[env.MERGESTAT_REPO_ID, .author.login, .body, .closed, .closedAt, .comments.totalCount, .createdAt, .createdViaEmail, .databaseId, .editor.login, .includesCreatedEdit, .labels.totalCount, .lastEditedAt, .locked, .milestone.totalCount, .number, .participants.totalCount, .publishedAt, .reactions.totalCount, .state, .title, .updatedAt, .url, .all_labels] | @csv' \
+  | psql $MERGESTAT_POSTGRES_URL -1 \
+    -c "DELETE FROM public.github_issues WHERE repo_id = '$MERGESTAT_REPO_ID'" \
+    -c "\copy public.github_issues (repo_id, author_login, body, closed, closed_at, comment_count, created_at, created_via_email, database_id, editor_login, includes_created_edit, label_count, last_edited_at, locked, milestone_count, number, participant_count, published_at, reaction_count, state, title, updated_at, url, labels) FROM stdin (FORMAT csv)";
+

--- a/syncs/github/issues/query.gql
+++ b/syncs/github/issues/query.gql
@@ -1,0 +1,57 @@
+query($owner: String!, $repo: String!, $endCursor: String) {
+  repository(owner: $owner, name: $repo) {
+    name
+    issues(first:10, after: $endCursor) {
+      nodes {
+        author {
+          login
+        }
+        body
+        closed
+        closedAt
+        comments {
+          totalCount
+        }
+        createdAt
+        createdViaEmail
+        databaseId
+        editor {
+          login
+        }
+        includesCreatedEdit
+        isReadByViewer
+        labels(first: 15) {
+          totalCount
+          nodes {
+            name
+          }
+        }
+        lastEditedAt
+        locked
+        milestone {
+          number
+        }
+        number
+        participants {
+          totalCount
+        }
+        publishedAt
+        reactions {
+          totalCount
+        }
+        publishedAt
+        reactions {
+          totalCount
+        }
+        state
+        title
+        updatedAt
+        url
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+    }
+  }
+}


### PR DESCRIPTION
Migrate our existing github issue syncer from [`internal/syncer/github_repo_issues.go`](https://github.com/mergestat/mergestat/blob/fd0443d84d4f75ec3d9d431bafcb4249653ef6f0/internal/syncer/github_repo_issues.go)

Related To: mergestat/internal#143