### PR TITLE
feat: separate action for non-main commits

### DIFF
--- a/.github/workflows/publish-container-images-branches.yml
+++ b/.github/workflows/publish-container-images-branches.yml
@@ -1,0 +1,79 @@
+name: Publish Docker Images
+# NOTE: some inspiration from here: https://code.dblock.org/2021/09/03/generating-task-matrix-by-looping-over-repo-files-with-github-actions.html
+on:
+  push:
+    branches:
+      - '**'
+      - '!main'
+jobs:
+  list-syncs:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v3
+      - id: set-matrix
+        run: echo "matrix=$(ls syncs/ | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
+  docker:
+    # only publish docker image if the PR is from a MergeStat repo
+    if: github.repository_owner == 'mergestat'
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    needs: list-syncs
+    strategy:
+      matrix:
+        syncs: ${{ fromJson(needs.list-syncs.outputs.matrix) }}
+    steps:
+      - 
+        name: Checkout
+        uses: actions/checkout@v3
+      -
+        name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          # list of Docker images to use as base name for tags
+          images: |
+            mergestat/sync-${{ matrix.syncs }}
+          # generate Docker tags based on the following events/attributes
+          tags: |
+            type=schedule
+            type=ref,event=branch
+            type=ref,event=pr
+            type=sha
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - 
+        name: Install Cosign
+        uses: sigstore/cosign-installer@v2.8.1
+        # Only sign the container if this is a release tag
+        # if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: ./syncs/${{ matrix.syncs }}
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+      
+      - 
+        name: Sign the images with GitHub OIDC Token
+        run: cosign sign ${TAGS}
+        env:
+          TAGS: ${{ steps.meta.outputs.tags }}
+          COSIGN_EXPERIMENTAL: true
+        # Only sign the container if this is a release tag
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}


### PR DESCRIPTION
Adds a GitHub Action that runs on non-`main` branches to publish images