### PR TITLE
chore: all merges into `main` should publish `:latest`

### DIFF
--- a/.github/workflows/publish-container-images.yml
+++ b/.github/workflows/publish-container-images.yml
@@ -49,6 +49,7 @@ jobs:
             type=ref,event=pr
             type=sha
             type=raw,value=${{ steps.version.outputs.version }}
+            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v2


### PR DESCRIPTION
This will allow users to pin to `latest` and automatically run the latest version of the sync. Closes #31 