### PR TITLE
chore: set `fail-fast: false`

### DIFF
--- a/.github/workflows/publish-container-images-branches.yml
+++ b/.github/workflows/publish-container-images-branches.yml
@@ -24,6 +24,7 @@ jobs:
       packages: write
     needs: list-syncs
     strategy:
+      fail-fast: false
       matrix:
         syncs: ${{ fromJson(needs.list-syncs.outputs.matrix) }}
     steps:


### PR DESCRIPTION
See here: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast

This should not fail the entire matrix if one job in it fails.