### PR TITLE
Run git syncs in transactions

### DIFF
--- a/syncs/git-blame/entrypoint.sh
+++ b/syncs/git-blame/entrypoint.sh
@@ -20,7 +20,9 @@ psql $MERGESTAT_POSTGRES_URL -1 --quiet --file /syncer/schema.sql
 git-blame-to-csv /mergestat/repo blame.csv
 
 # load the data into postgres
-cat blame.csv | psql $MERGESTAT_POSTGRES_URL -1 \
-  -c "\set ON_ERROR_STOP on" \
-  -c "DELETE FROM public.git_blame WHERE repo_id = '$MERGESTAT_REPO_ID'" \
-  -c "\copy public.git_blame (repo_id, author_email, author_name, author_when, commit_hash, line_no, line, path) FROM stdin (FORMAT csv)"
+cat blame.csv | psql $MERGESTAT_POSTGRES_URL --quiet <<EOF
+  BEGIN;
+    DELETE FROM public.git_blame WHERE repo_id = '$MERGESTAT_REPO_ID';
+    COPY public.git_blame (repo_id, author_email, author_name, author_when, commit_hash, line_no, line, path) FROM stdin (FORMAT csv);
+  COMMIT;
+EOF

--- a/syncs/git-commit-stats/entrypoint.sh
+++ b/syncs/git-commit-stats/entrypoint.sh
@@ -22,7 +22,9 @@ mergestat "SELECT '$MERGESTAT_REPO_ID', hash, file_path, additions, deletions, o
 
 
 # load the data into postgres
-cat commit-stats.csv | psql $MERGESTAT_POSTGRES_URL -1 \
-  -c "\set ON_ERROR_STOP on" \
-  -c "DELETE FROM public.git_commit_stats WHERE repo_id = '$MERGESTAT_REPO_ID'" \
-  -c "\copy public.git_commit_stats (repo_id, commit_hash, file_path, additions, deletions, old_file_mode, new_file_mode) FROM stdin (FORMAT csv)"
+cat commit-stats.csv | psql $MERGESTAT_POSTGRES_URL --quiet <<EOF
+  BEGIN;
+    DELETE FROM public.git_commit_stats WHERE repo_id = '$MERGESTAT_REPO_ID';
+    COPY public.git_commit_stats (repo_id, commit_hash, file_path, additions, deletions, old_file_mode, new_file_mode) FROM stdin (FORMAT csv);
+  COMMIT;
+EOF

--- a/syncs/git-commits/entrypoint.sh
+++ b/syncs/git-commits/entrypoint.sh
@@ -25,7 +25,9 @@ mergestat "SELECT '$MERGESTAT_REPO_ID', hash, message, author_name, author_email
 
 
 # load the data into postgres
-cat commits.csv | psql $MERGESTAT_POSTGRES_URL -1 \
-  -c "\set ON_ERROR_STOP on" \
-  -c "DELETE FROM public.git_commits WHERE repo_id = '$MERGESTAT_REPO_ID'" \
-  -c "\copy public.git_commits (repo_id, hash, message, author_name, author_email, author_when, committer_name, committer_email, committer_when, parents) FROM stdin (FORMAT csv)"
+cat commits.csv | psql $MERGESTAT_POSTGRES_URL --quiet <<EOF
+  BEGIN;
+    DELETE FROM public.git_commits WHERE repo_id = '$MERGESTAT_REPO_ID';
+    COPY public.git_commits (repo_id, hash, message, author_name, author_email, author_when, committer_name, committer_email, committer_when, parents) FROM stdin (FORMAT csv)"
+  COMMIT;
+EOF

--- a/syncs/git-files/entrypoint.sh
+++ b/syncs/git-files/entrypoint.sh
@@ -22,7 +22,9 @@ mergestat "SELECT '$MERGESTAT_REPO_ID', path, executable, CASE (instr(cast(conte
     -r /mergestat/repo > files.csv
 
 # load the data into postgres
-cat files.csv | psql $MERGESTAT_POSTGRES_URL -1 \
-  -c "\set ON_ERROR_STOP on" \
-  -c "DELETE FROM public.git_files WHERE repo_id = '$MERGESTAT_REPO_ID'" \
-  -c "\copy public.git_files (repo_id, path, executable, contents) FROM stdin (FORMAT csv)"
+cat files.csv | psql $MERGESTAT_POSTGRES_URL --quiet <<EOF
+  BEGIN;
+    DELETE FROM public.git_files WHERE repo_id = '$MERGESTAT_REPO_ID';
+    COPY public.git_files (repo_id, path, executable, contents) FROM stdin (FORMAT csv);
+  COMMIT;
+EOF

--- a/syncs/git-refs/entrypoint.sh
+++ b/syncs/git-refs/entrypoint.sh
@@ -19,7 +19,9 @@ psql $MERGESTAT_POSTGRES_URL -1 --quiet --file /syncer/schema.sql
 # extract data and import into mergestat
 mergestat --format json 'SELECT *, COALESCE(COMMIT_FROM_TAG(tag), hash) AS tag_commit_hash FROM refs' -r /mergestat/repo \
   | jq -rc '.[] | [env.MERGESTAT_REPO_ID, .full_name, .name, .hash, .remote, .target, .type, .tag_commit_hash] | @csv' \
-  | psql $MERGESTAT_POSTGRES_URL -1 --quiet \
-      -c "\set ON_ERROR_STOP on" \
-      -c "DELETE FROM public.git_refs WHERE repo_id = '$MERGESTAT_REPO_ID'" \
-      -c "\copy public.git_refs (repo_id, full_name, name, hash, remote, target, type, tag_commit_hash) FROM stdin (FORMAT csv)";
+  | psql $MERGESTAT_POSTGRES_URL --quiet <<EOF
+  BEGIN;
+    DELETE FROM public.git_refs WHERE repo_id = '$MERGESTAT_REPO_ID';
+    COPY public.git_refs (repo_id, full_name, name, hash, remote, target, type, tag_commit_hash) FROM stdin (FORMAT csv);
+  COMMIT;
+EOF


### PR DESCRIPTION
This should prevent the cases in which the sync works only partially resulting in missing data or "blips" in specific repo data. Since there are no tests and I don't have a full local setup I'm not sure how to test it though 😅 