### PR TITLE
feat: building bearer image with debug

### DIFF
--- a/syncs/scan-bearer/Dockerfile
+++ b/syncs/scan-bearer/Dockerfile
@@ -1,14 +1,11 @@
-FROM bearer/bearer:1.3.0 AS bearer
-
-FROM alpine:3.17.3
-
-COPY --from=bearer /usr/local/bin/bearer /usr/local/bin/bearer
+FROM golang:1.19-alpine3.16 AS builder
 
 # install latest version of git, psql and jq
-RUN apk upgrade && apk add --no-cache git postgresql-client jq
+RUN apk upgrade && apk add --no-cache git postgresql-client jq build-base
 
 RUN mkdir -p /syncer
 COPY . /syncer/
+RUN cd /syncer && ./install-bearer.sh
 
 LABEL com.mergestat.sync.clone="true"
 

--- a/syncs/scan-bearer/entrypoint.sh
+++ b/syncs/scan-bearer/entrypoint.sh
@@ -14,7 +14,7 @@ set -euo pipefail
 
 psql $MERGESTAT_POSTGRES_URL -1 --quiet --file /syncer/schema.sql
 
-bearer scan /mergestat/repo --format json --output _mergestat_bearer_scan_results.json
+bearer scan /mergestat/repo --debug --format json --output _mergestat_bearer_scan_results.json
 
 jq -rc '[env.MERGESTAT_REPO_ID, . | tostring] | @csv' _mergestat_bearer_scan_results.json \
   | psql $MERGESTAT_POSTGRES_URL -1 --quiet \

--- a/syncs/scan-bearer/install-bearer.sh
+++ b/syncs/scan-bearer/install-bearer.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+
+git clone https://github.com/Bearer/bearer
+cd bearer/cmd/bearer
+go build
+cp bearer /usr/bin
+cd /usr/bin
+chmod +x bearer


### PR DESCRIPTION
Locally building the bearer image so it is built with arm64 architecture as we seem to be having issues with the amd64 image that is the image the maintainers post.

Test image is located [here](https://hub.docker.com/repository/docker/josuemergestat/test-scan-bearer/general)

Local run times for syncs are improved even without changing anything related to storage.