### PR TITLE
chore: refactor `gosec` execution

### DIFF
--- a/syncs/scan-gosec/Dockerfile
+++ b/syncs/scan-gosec/Dockerfile
@@ -7,7 +7,8 @@ RUN apk upgrade && apk add --no-cache curl postgresql-client jq
 # TODO(@riyaz): remove script piping and do manual checksum verification
 RUN curl -sfL https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh -s - -b /usr/local/bin v2.14.0
 
+COPY . /syncer/
 LABEL com.mergestat.sync.clone="true"
 
-COPY entrypoint.sh /entrypoint.sh
-ENTRYPOINT [ "/entrypoint.sh" ]
+
+ENTRYPOINT [ "/syncer/entrypoint.sh" ]

--- a/syncs/scan-gosec/entrypoint.sh
+++ b/syncs/scan-gosec/entrypoint.sh
@@ -15,6 +15,8 @@ set -euo pipefail
 #
 # @author: Riyaz Ali (riyaz@mergestat.com)
 
+psql $MERGESTAT_POSTGRES_URL -1 --quiet --file /syncer/schema.sql
+
 /usr/local/bin/gosec -fmt json /mergestat/repo > _mergestat_gosec_scan_results.json
 
 cat _mergestat_gosec_scan_results.json \

--- a/syncs/scan-gosec/entrypoint.sh
+++ b/syncs/scan-gosec/entrypoint.sh
@@ -15,7 +15,9 @@ set -euo pipefail
 #
 # @author: Riyaz Ali (riyaz@mergestat.com)
 
-(cd /mergestat/repo && /usr/local/bin/gosec -no-fail -fmt json ./...) \
+/usr/local/bin/gosec -fmt json /mergestat/repo > _mergestat_gosec_scan_results.json
+
+cat _mergestat_gosec_scan_results.json \
     | jq -rc '.Issues | map(. + { "file": .file | sub("/src"; .file) }) | [env.MERGESTAT_REPO_ID, (. | tostring)] | @csv' \
     | psql $MERGESTAT_POSTGRES_URL -1 \
         -c "\set ON_ERROR_STOP on" \

--- a/syncs/scan-gosec/schema.sql
+++ b/syncs/scan-gosec/schema.sql
@@ -1,0 +1,35 @@
+CREATE TABLE IF NOT EXISTS gosec_repo_scans (
+    repo_id uuid PRIMARY KEY REFERENCES repos(id) ON DELETE CASCADE ON UPDATE RESTRICT,
+    issues jsonb NOT NULL,
+    _mergestat_synced_at timestamp with time zone NOT NULL DEFAULT now()
+);
+COMMENT ON TABLE gosec_repo_scans IS 'Table of gosec repo scans';
+COMMENT ON COLUMN gosec_repo_scans.repo_id IS 'foreign key for public.repos.id';
+COMMENT ON COLUMN gosec_repo_scans.issues IS 'JSON issues from gosec repo scan';
+COMMENT ON COLUMN gosec_repo_scans._mergestat_synced_at IS 'timestamp when record was synced into the MergeStat database';
+
+CREATE UNIQUE INDEX IF NOT EXISTS gosec_repo_scans_pkey ON gosec_repo_scans(repo_id uuid_ops);
+
+CREATE OR REPLACE VIEW gosec_repo_detections AS SELECT gosec_repo_scans.repo_id,
+    issue.value ->> 'severity'::text AS severity,
+    issue.value ->> 'confidence'::text AS confidence,
+    (issue.value -> 'cwe'::text) ->> 'id'::text AS cwe_id,
+    issue.value ->> 'rule_id'::text AS rule_id,
+    issue.value ->> 'details'::text AS details,
+    issue.value ->> 'file'::text AS file,
+    issue.value ->> 'line'::text AS line,
+    issue.value ->> 'column'::text AS "column",
+    issue.value ->> 'nosec'::text AS nosec
+   FROM gosec_repo_scans,
+    LATERAL jsonb_array_elements(gosec_repo_scans.issues) issue(value);
+COMMENT ON VIEW gosec_repo_detections IS 'view of gosec repo scan detections';
+COMMENT ON COLUMN gosec_repo_detections.repo_id IS 'foreign key for public.repos.id';
+COMMENT ON COLUMN gosec_repo_detections.severity IS 'detection severity';
+COMMENT ON COLUMN gosec_repo_detections.confidence IS 'detection confidence';
+COMMENT ON COLUMN gosec_repo_detections.cwe_id IS 'detection CWE (Common Weakness Enumeration) ID';
+COMMENT ON COLUMN gosec_repo_detections.rule_id IS 'detection rule ID';
+COMMENT ON COLUMN gosec_repo_detections.details IS 'detection details';
+COMMENT ON COLUMN gosec_repo_detections.file IS 'detection file';
+COMMENT ON COLUMN gosec_repo_detections.line IS 'detection line in file';
+COMMENT ON COLUMN gosec_repo_detections."column" IS 'detection column in line';
+COMMENT ON COLUMN gosec_repo_detections.nosec IS 'flag to determine if #nosec annotation was used';


### PR DESCRIPTION
- add schema file
- split execution into multiple steps