### PR TITLE
feat: add multi-arch images

### DIFF
--- a/.github/workflows/publish-container-images-branches.yml
+++ b/.github/workflows/publish-container-images-branches.yml
@@ -70,6 +70,7 @@ jobs:
         name: Build and push
         uses: docker/build-push-action@v3
         with:
+          platforms: linux/amd64,linux/arm64
           context: ./syncs/${{ matrix.syncs }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/publish-container-images.yml
+++ b/.github/workflows/publish-container-images.yml
@@ -75,6 +75,7 @@ jobs:
         name: Build and push
         uses: docker/build-push-action@v3
         with:
+          platforms: linux/amd64,linux/arm64
           context: ./syncs/${{ matrix.syncs }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
Adding support for `arm64` images on top of the `amd64` images we were already publishing.