### PR TITLE
chore: add some basic `README.md` files

### DIFF
--- a/syncs/git-blame/README.md
+++ b/syncs/git-blame/README.md
@@ -1,0 +1,3 @@
+## `git-blame`
+
+This sync stores Git blame data about every file in a repo in PostgreSQL.

--- a/syncs/git-commit-stats/README.md
+++ b/syncs/git-commit-stats/README.md
@@ -1,0 +1,3 @@
+## `git-commit-stats`
+
+This sync stores Git commit stats data of a repo in PostgreSQL.

--- a/syncs/git-commits/README.md
+++ b/syncs/git-commits/README.md
@@ -1,0 +1,3 @@
+## `git-commits`
+
+This sync stores Git commit data of a repo in PostgreSQL.

--- a/syncs/git-files/README.md
+++ b/syncs/git-files/README.md
@@ -1,0 +1,3 @@
+## `git-files`
+
+This sync stores Git file data from a repo in PostgreSQL.

--- a/syncs/git-refs/README.md
+++ b/syncs/git-refs/README.md
@@ -1,0 +1,3 @@
+## `git-refs`
+
+This sync stores Git ref data of a repo in PostgreSQL.

--- a/syncs/github-dependabot/README.md
+++ b/syncs/github-dependabot/README.md
@@ -1,0 +1,3 @@
+## `github-dependabot`
+
+This sync uses the GitHub API to retrieve the Dependabot alerts on a repo and stores the results in PostgreSQL.

--- a/syncs/github-issues/README.md
+++ b/syncs/github-issues/README.md
@@ -1,0 +1,3 @@
+## `github-issues`
+
+This sync uses the GitHub API to retrieve the issues of a repo and stores the results in PostgreSQL.

--- a/syncs/github-pull-request-commits/README.md
+++ b/syncs/github-pull-request-commits/README.md
@@ -1,0 +1,3 @@
+## `github-pull-request-commits`
+
+This sync uses the GitHub API to retrieve the PR commits of a repo and stores the results in PostgreSQL.

--- a/syncs/github-pull-request-reviews/README.md
+++ b/syncs/github-pull-request-reviews/README.md
@@ -1,0 +1,3 @@
+## `github-pull-request-reviews`
+
+This sync uses the GitHub API to retrieve the PR reviews of a repo and stores the results in PostgreSQL.

--- a/syncs/github-pull-requests/README.md
+++ b/syncs/github-pull-requests/README.md
@@ -1,0 +1,3 @@
+## `github-pull-requests`
+
+This sync uses the GitHub API to retrieve the PRs of a repo and stores the results in PostgreSQL.

--- a/syncs/github-repo-info/README.md
+++ b/syncs/github-repo-info/README.md
@@ -1,0 +1,3 @@
+## `github-repo-info`
+
+This sync uses the GitHub API to retrieve info/metadata about a repo and stores the results in PostgreSQL.

--- a/syncs/github-repo-stargazers/README.md
+++ b/syncs/github-repo-stargazers/README.md
@@ -1,0 +1,3 @@
+## `github-repo-stargazers`
+
+This sync uses the GitHub API to retrieve stars of a repo and stores the results in PostgreSQL.

--- a/syncs/scan-gitleaks/README.md
+++ b/syncs/scan-gitleaks/README.md
@@ -1,0 +1,3 @@
+## `gitleaks`
+
+This sync runs the open-source [`gitleaks`](https://github.com/gitleaks/gitleaks) scanner on a git repository and stores results in PostgreSQL.

--- a/syncs/scan-gosec/README.md
+++ b/syncs/scan-gosec/README.md
@@ -1,0 +1,3 @@
+## `scan-gosec`
+
+This sync runs the open-source [`gosec`](https://github.com/securego/gosec) scanner on a git repository and stores results in PostgreSQL.

--- a/syncs/scan-grype/README.md
+++ b/syncs/scan-grype/README.md
@@ -1,0 +1,3 @@
+## `scan-grype`
+
+This sync runs the open-source [`grype`](https://github.com/anchore/grype) scanner on a git repository and stores results in PostgreSQL.

--- a/syncs/scan-syft/README.md
+++ b/syncs/scan-syft/README.md
@@ -1,0 +1,3 @@
+## `syft`
+
+This sync runs the open-source [`syft`](https://github.com/anchore/syft) SBOM generator on a git repository and stores results in PostgreSQL.

--- a/syncs/scan-trivy/README.md
+++ b/syncs/scan-trivy/README.md
@@ -1,0 +1,3 @@
+## `scan-trivy`
+
+This sync runs the open-source [`trivy`](https://github.com/aquasecurity/trivy) scanner on a git repository and stores results in PostgreSQL.

--- a/syncs/scan-yelp-detect-secrets/README.md
+++ b/syncs/scan-yelp-detect-secrets/README.md
@@ -1,0 +1,3 @@
+## `yelp-detect-secrets`
+
+This sync runs the open-source [`detect-secrets`](https://github.com/Yelp/detect-secrets) scanner on a git repository and stores results in PostgreSQL.


### PR DESCRIPTION
to each sync directory. Makes direct linking to a sync implementation look a bit nicer.