### PR TITLE
Git-files: Removing invalid UTF-8 characters

### DIFF
--- a/syncs/git-files/entrypoint.sh
+++ b/syncs/git-files/entrypoint.sh
@@ -21,8 +21,11 @@ mergestat "SELECT '$MERGESTAT_REPO_ID', path, executable, CASE (instr(cast(conte
     -f csv-noheader \
     -r /mergestat/repo > files.csv
 
+# Assuming input file is UTF-8 and converting to UTF-8 but skipping invalid characters
+iconv -f UTF-8 -t UTF-8 -c < files.csv > files_utf8.csv
+
 # load the data into postgres
-cat files.csv | psql $MERGESTAT_POSTGRES_URL -1 \
+cat files_utf8.csv | psql $MERGESTAT_POSTGRES_URL -1 \
   -c "\set ON_ERROR_STOP on" \
   -c "DELETE FROM public.git_files WHERE repo_id = '$MERGESTAT_REPO_ID'" \
   -c "\copy public.git_files (repo_id, path, executable, contents) FROM stdin (FORMAT csv)"


### PR DESCRIPTION
Removes invalid character sequences from the files.csv file prior to loading it into the UTF-8 encoded postgres schema

Fixes #43

---
### Notes
I have been struck with the UTF-8 encoding error returned by Postgres a couple of times. I've forked the git-files sync docker image and applied this patch to fix the issue.

The same fix can be applied to git-blame

It does result in a loss of information, since the invalid characters are just removed

Feel free to do with this commit as you please. I am just providing it as an example of how I solved the issue.