### PR TITLE
fix: replace skypack.dev with jsdelivr.com

### DIFF
--- a/syncs/github-dependabot/main.ts
+++ b/syncs/github-dependabot/main.ts
@@ -8,7 +8,7 @@
 //
 // @author: Patrick DeVivo (patrick@mergestat.com)
 
-import { Octokit } from "https://cdn.skypack.dev/octokit?dts";
+import { Octokit } from "https://cdn.jsdelivr.net/npm/octokit@2.0.19/+esm";
 import { Client } from "https://deno.land/x/postgres@v0.17.0/mod.ts";
 
 const repoID = Deno.env.get("MERGESTAT_REPO_ID")

--- a/syncs/github-issues/main.ts
+++ b/syncs/github-issues/main.ts
@@ -8,8 +8,8 @@
 //
 // @author: Patrick DeVivo (patrick@mergestat.com)
 
-import { Octokit } from "https://cdn.skypack.dev/octokit?dts";
-import { paginateGraphql } from "https://cdn.skypack.dev/@octokit/plugin-paginate-graphql";
+import { Octokit } from "https://cdn.jsdelivr.net/npm/octokit@2.0.19/+esm";
+import { paginateGraphql } from "https://cdn.jsdelivr.net/npm/@octokit/plugin-paginate-graphql@2.0.1/+esm";
 import { Client } from "https://deno.land/x/postgres@v0.17.0/mod.ts";
 
 const query = await Deno.readTextFile("./query.gql");

--- a/syncs/github-prs-and-pr-commits/main.ts
+++ b/syncs/github-prs-and-pr-commits/main.ts
@@ -7,7 +7,7 @@
 //
 // @author: Patrick DeVivo (patrick@mergestat.com)
 
-import { Octokit } from "https://cdn.skypack.dev/octokit?dts";
+import { Octokit } from "https://cdn.jsdelivr.net/npm/octokit@2.0.19/+esm";
 import { Client } from "https://deno.land/x/postgres@v0.17.0/mod.ts";
 
 const repoID = Deno.env.get("MERGESTAT_REPO_ID")

--- a/syncs/github-pull-requests/main.ts
+++ b/syncs/github-pull-requests/main.ts
@@ -8,8 +8,8 @@
 //
 // @author: Patrick DeVivo (patrick@mergestat.com)
 
-import { Octokit } from "https://cdn.skypack.dev/octokit?dts";
-import { paginateGraphql } from "https://cdn.skypack.dev/@octokit/plugin-paginate-graphql";
+import { Octokit } from "https://cdn.jsdelivr.net/npm/octokit@2.0.19/+esm";
+import { paginateGraphql } from "https://cdn.jsdelivr.net/npm/@octokit/plugin-paginate-graphql@2.0.1/+esm";
 import { Client } from "https://deno.land/x/postgres@v0.17.0/mod.ts";
 
 const query = await Deno.readTextFile("./query.gql");

--- a/syncs/github-repo-info/main.ts
+++ b/syncs/github-repo-info/main.ts
@@ -8,7 +8,7 @@
 //
 // @author: Patrick DeVivo (patrick@mergestat.com)
 
-import { Octokit } from "https://cdn.skypack.dev/octokit?dts";
+import { Octokit } from "https://cdn.jsdelivr.net/npm/octokit@2.0.19/+esm";
 import { Client } from "https://deno.land/x/postgres@v0.17.0/mod.ts";
 
 const repoID = Deno.env.get("MERGESTAT_REPO_ID")

--- a/syncs/github-repo-stargazers/main.ts
+++ b/syncs/github-repo-stargazers/main.ts
@@ -8,8 +8,8 @@
 //
 // @author: Patrick DeVivo (patrick@mergestat.com)
 
-import { Octokit } from "https://cdn.skypack.dev/octokit?dts";
-import { paginateGraphql } from "https://cdn.skypack.dev/@octokit/plugin-paginate-graphql";
+import { Octokit } from "https://cdn.jsdelivr.net/npm/octokit@2.0.19/+esm";
+import { paginateGraphql } from "https://cdn.jsdelivr.net/npm/@octokit/plugin-paginate-graphql@2.0.1/+esm";
 import { Client } from "https://deno.land/x/postgres@v0.17.0/mod.ts";
 
 const query = await Deno.readTextFile("./query.gql");


### PR DESCRIPTION
Replace `skypack.dev` with `jsdelivr.com`. Fixes #69. See [this comment for more details](https://github.com/mergestat/syncs/issues/69#issuecomment-1566646782)