### PR TITLE
fix: drop octokit version to address oauth issue

### DIFF
--- a/syncs/github-dependabot/main.ts
+++ b/syncs/github-dependabot/main.ts
@@ -8,7 +8,7 @@
 //
 // @author: Patrick DeVivo (patrick@mergestat.com)
 
-import { Octokit } from "https://esm.sh/octokit@2.0.19";
+import { Octokit } from "https://esm.sh/octokit@2.0.14";
 import { Client } from "https://deno.land/x/postgres@v0.17.0/mod.ts";
 
 const repoID = Deno.env.get("MERGESTAT_REPO_ID")

--- a/syncs/github-issues/main.ts
+++ b/syncs/github-issues/main.ts
@@ -8,7 +8,7 @@
 //
 // @author: Patrick DeVivo (patrick@mergestat.com)
 
-import { Octokit } from "https://esm.sh/octokit@2.0.19";
+import { Octokit } from "https://esm.sh/octokit@2.0.14";
 import { paginateGraphql } from "https://cdn.jsdelivr.net/npm/@octokit/plugin-paginate-graphql@2.0.1/+esm";
 import { Client } from "https://deno.land/x/postgres@v0.17.0/mod.ts";
 

--- a/syncs/github-prs-and-pr-commits/main.ts
+++ b/syncs/github-prs-and-pr-commits/main.ts
@@ -7,7 +7,7 @@
 //
 // @author: Patrick DeVivo (patrick@mergestat.com)
 
-import { Octokit } from "https://esm.sh/octokit@2.0.19";
+import { Octokit } from "https://esm.sh/octokit@2.0.14";
 import { Client } from "https://deno.land/x/postgres@v0.17.0/mod.ts";
 
 const repoID = Deno.env.get("MERGESTAT_REPO_ID")

--- a/syncs/github-pull-requests/main.ts
+++ b/syncs/github-pull-requests/main.ts
@@ -8,7 +8,7 @@
 //
 // @author: Patrick DeVivo (patrick@mergestat.com)
 
-import { Octokit } from "https://esm.sh/octokit@2.0.19";
+import { Octokit } from "https://esm.sh/octokit@2.0.14";
 import { paginateGraphql } from "https://cdn.jsdelivr.net/npm/@octokit/plugin-paginate-graphql@2.0.1/+esm";
 import { Client } from "https://deno.land/x/postgres@v0.17.0/mod.ts";
 

--- a/syncs/github-repo-info/main.ts
+++ b/syncs/github-repo-info/main.ts
@@ -8,7 +8,7 @@
 //
 // @author: Patrick DeVivo (patrick@mergestat.com)
 
-import { Octokit } from "https://esm.sh/octokit@2.0.19";
+import { Octokit } from "https://esm.sh/octokit@2.0.14";
 import { Client } from "https://deno.land/x/postgres@v0.17.0/mod.ts";
 
 const repoID = Deno.env.get("MERGESTAT_REPO_ID")

--- a/syncs/github-repo-stargazers/main.ts
+++ b/syncs/github-repo-stargazers/main.ts
@@ -8,7 +8,7 @@
 //
 // @author: Patrick DeVivo (patrick@mergestat.com)
 
-import { Octokit } from "https://esm.sh/octokit@2.0.19";
+import { Octokit } from "https://esm.sh/octokit@2.0.14";
 import { paginateGraphql } from "https://cdn.jsdelivr.net/npm/@octokit/plugin-paginate-graphql@2.0.1/+esm";
 import { Client } from "https://deno.land/x/postgres@v0.17.0/mod.ts";
 


### PR DESCRIPTION
Dropping to version 2.0.14 seeing the comments and issues related to this [issue](https://github.com/octokit/octokit.js/issues/2450). All my local tests are passing now.