### PR TITLE
feat: implement a sync for GitHub Issue Comments

### DIFF
--- a/syncs/github-issue-comments/Dockerfile
+++ b/syncs/github-issue-comments/Dockerfile
@@ -1,0 +1,13 @@
+FROM denoland/deno:1.32.3
+
+WORKDIR /app
+
+# Prefer not to run as root.
+USER deno
+
+COPY . .
+
+# Compile the main app so that it doesn't need to be compiled each startup/entry.
+RUN deno cache main.ts
+
+CMD ["run", "--allow-net", "--allow-env", "--allow-read", "main.ts"]

--- a/syncs/github-issue-comments/README.md
+++ b/syncs/github-issue-comments/README.md
@@ -1,0 +1,3 @@
+## `github-issue-comments`
+
+This sync uses the GitHub API to retrieve comments on issues of a repo and stores the results in PostgreSQL.

--- a/syncs/github-issue-comments/main.ts
+++ b/syncs/github-issue-comments/main.ts
@@ -1,0 +1,82 @@
+//  _ __ ___   ___ _ __ __ _  ___ ___| |_ __ _| |_
+// | '_ ` _ \ / _ | '__/ _` |/ _ / __| __/ _` | __|
+// | | | | | |  __| | | (_| |  __\__ | || (_| | |_
+// |_| |_| |_|\___|_|  \__, |\___|___/\__\__,_|\__|
+//                     |___/
+//
+// This syncer uses the GitHub API to sync issue comments for the given repository.
+//
+// @author: Patrick DeVivo (patrick@mergestat.com)
+
+import { Octokit } from "https://esm.sh/v124/octokit@2.0.14";
+import { throttling } from "https://esm.sh/@octokit/plugin-throttling";
+import { Client } from "https://deno.land/x/postgres@v0.17.0/mod.ts";
+
+const repoID = Deno.env.get("MERGESTAT_REPO_ID")
+const repoURL = new URL(Deno.env.get("MERGESTAT_REPO_URL") || "");
+const owner = repoURL.pathname.split("/")[1];
+const repo = repoURL.pathname.split("/")[2];
+
+const OctokitWithThrottling = Octokit.plugin(throttling);
+const octokit = new OctokitWithThrottling({
+    auth: Deno.env.get("MERGESTAT_AUTH_TOKEN"),
+    throttle: {
+        onRateLimit: (retryAfter, options, octokit, retryCount) => {
+          octokit.log.warn(
+            `Request quota exhausted for request ${options.method} ${options.url}`
+          );
+    
+          if (retryCount < 1) {
+            // only retries once
+            octokit.log.info(`Retrying after ${retryAfter} seconds!`);
+            return true;
+          }
+        },
+        onSecondaryRateLimit: (retryAfter, options, octokit) => {
+          // does not retry, only logs a warning
+          octokit.log.warn(
+            `SecondaryRateLimit detected for request ${options.method} ${options.url}`
+          );
+        },
+      },
+});
+const commentsBuffer = [];
+
+const iterator = octokit.paginate.iterator(`GET /repos/${owner}/${repo}/issues/comments`, {
+    headers: {
+        'X-GitHub-Api-Version': '2022-11-28'
+    },
+    owner, repo
+});
+  
+for await (const { data: comments } of iterator) {
+    console.log(`fetched page of issue comments for: ${owner}/${repo} (${comments.length} comments)`)
+    for (const alert of comments) {
+        commentsBuffer.push(alert)
+    }
+}
+
+console.log(`fetched ${commentsBuffer.length} issue comments for: ${owner}/${repo}`)
+
+const schemaSQL = await Deno.readTextFile("./schema.sql");
+const client = new Client(Deno.env.get("MERGESTAT_POSTGRES_URL"));
+await client.connect();
+
+const tx = await client.createTransaction("syncs/github-issue-comments");
+await tx.begin()
+
+await tx.queryArray(schemaSQL);
+await tx.queryArray(`DELETE FROM public.github_issue_comments WHERE repo_id = $1;`, [repoID]);
+for await (const comment of commentsBuffer) {
+    await tx.queryArray(`
+INSERT INTO public.github_issue_comments (repo_id, id, node_id, issue_number, url, user_login, user_id, user_type, user_avatar_url, user_url, created_at, updated_at, author_association, body, reactions)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
+    `, [repoID, comment.id, comment.node_id, comment.issue_url.split("/").pop(), comment.url, comment.user?.login, comment.user?.id, comment.user?.type, comment.user?.avatar_url, comment.user?.url, comment.created_at, comment.updated_at, comment.author_association, comment.body, JSON.stringify(comment.reactions)]);
+}
+await tx.commit();
+
+await client.end();
+
+console.log(`synced ${commentsBuffer.length} issue comments for: ${owner}/${repo} (repo_id: ${repoID})`)
+
+Deno.exit(0)

--- a/syncs/github-issue-comments/schema.sql
+++ b/syncs/github-issue-comments/schema.sql
@@ -1,6 +1,6 @@
 CREATE TABLE IF NOT EXISTS github_issue_comments (
     repo_id uuid REFERENCES repos(id) ON DELETE CASCADE ON UPDATE RESTRICT,
-    id integer,
+    id bigint,
     node_id text,
     issue_number integer,
     url text,
@@ -38,5 +38,4 @@ COMMENT ON COLUMN github_issue_comments.body IS 'body of the issue comment';
 COMMENT ON COLUMN github_issue_comments.reactions IS 'reactions on the issue comment';
 COMMENT ON COLUMN github_issue_comments._mergestat_synced_at IS 'timestamp when record was synced into the MergeStat database';
 
-CREATE UNIQUE INDEX IF NOT EXISTS github_issue_comments_pkey ON github_issue_comments(repo_id uuid_ops,id int4_ops);
 CREATE INDEX IF NOT EXISTS idx_github_issue_comments_repo_id_fkey ON github_issue_comments(repo_id uuid_ops);

--- a/syncs/github-issue-comments/schema.sql
+++ b/syncs/github-issue-comments/schema.sql
@@ -1,0 +1,42 @@
+CREATE TABLE IF NOT EXISTS github_issue_comments (
+    repo_id uuid REFERENCES repos(id) ON DELETE CASCADE ON UPDATE RESTRICT,
+    id integer,
+    node_id text,
+    issue_number integer,
+    url text,
+    user_login text,
+    user_id integer,
+    user_type text,
+    user_avatar_url text,
+    user_url text,
+    created_at timestamp with time zone,
+    updated_at timestamp with time zone,
+    author_association text,
+    body text,
+    reactions jsonb,
+
+    _mergestat_synced_at timestamp with time zone NOT NULL DEFAULT now(),
+    CONSTRAINT github_issue_comments_pkey PRIMARY KEY (repo_id, id)
+
+);
+
+COMMENT ON TABLE github_issue_comments IS 'issue comments of a GitHub repo';
+COMMENT ON COLUMN github_issue_comments.repo_id IS 'foreign key for public.repos.id';
+COMMENT ON COLUMN github_issue_comments.id IS 'id of the issue comment';
+COMMENT ON COLUMN github_issue_comments.node_id IS 'node id of the issue comment';
+COMMENT ON COLUMN github_issue_comments.issue_number IS 'issue number';
+COMMENT ON COLUMN github_issue_comments.url IS 'URL to the issue comment';
+COMMENT ON COLUMN github_issue_comments.user_login IS 'login of the user who created the issue comment';
+COMMENT ON COLUMN github_issue_comments.user_id IS 'login of the user who created the issue comment';
+COMMENT ON COLUMN github_issue_comments.user_type IS 'type of the user who created the issue comment';
+COMMENT ON COLUMN github_issue_comments.user_avatar_url IS 'avatar url of the user who created the issue comment';
+COMMENT ON COLUMN github_issue_comments.user_url IS 'url of the user who created the issue comment';
+COMMENT ON COLUMN github_issue_comments.created_at IS 'timestamp of when the issue comment was created';
+COMMENT ON COLUMN github_issue_comments.updated_at IS 'timestamp of when the issue comment was updated';
+COMMENT ON COLUMN github_issue_comments.author_association IS 'author association of the user who created the issue comment';
+COMMENT ON COLUMN github_issue_comments.body IS 'body of the issue comment';
+COMMENT ON COLUMN github_issue_comments.reactions IS 'reactions on the issue comment';
+COMMENT ON COLUMN github_issue_comments._mergestat_synced_at IS 'timestamp when record was synced into the MergeStat database';
+
+CREATE UNIQUE INDEX IF NOT EXISTS github_issue_comments_pkey ON github_issue_comments(repo_id uuid_ops,id int4_ops);
+CREATE INDEX IF NOT EXISTS idx_github_issue_comments_repo_id_fkey ON github_issue_comments(repo_id uuid_ops);


### PR DESCRIPTION
Follows existing patterns as best as possible to implement a sync for `github-issue-comments` (the comments on GitHub issues).

See the `schema.sql` file for additional details. Closes #83 