### PR TITLE
feat: implement `github-pr-review-comments` sync

### DIFF
--- a/syncs/github-pull-request-review-comments/Dockerfile
+++ b/syncs/github-pull-request-review-comments/Dockerfile
@@ -1,0 +1,13 @@
+FROM denoland/deno:1.32.3
+
+WORKDIR /app
+
+# Prefer not to run as root.
+USER deno
+
+COPY . .
+
+# Compile the main app so that it doesn't need to be compiled each startup/entry.
+RUN deno cache main.ts
+
+CMD ["run", "--allow-net", "--allow-env", "--allow-read", "main.ts"]

--- a/syncs/github-pull-request-review-comments/README.md
+++ b/syncs/github-pull-request-review-comments/README.md
@@ -1,0 +1,3 @@
+## `github-pull-request-review-comments`
+
+This sync uses the GitHub API to retrieve review comments on PRs of a repo and stores the results in PostgreSQL.

--- a/syncs/github-pull-request-review-comments/main.ts
+++ b/syncs/github-pull-request-review-comments/main.ts
@@ -69,15 +69,14 @@ await tx.queryArray(schemaSQL);
 await tx.queryArray(`DELETE FROM public.github_pr_review_comments WHERE repo_id = $1;`, [repoID]);
 for await (const comment of commentsBuffer) {
     await tx.queryArray(`
-INSERT INTO public.github_pr_review_comments (repo_id, url, pull_request_review_id, pull_request_number, id, node_id, diff_hunk, path, commit_id, original_commit_id, user_login, user_id, user_avatar_url, user_url, created_at, updated_at, author_association, body, reactions, start_line, original_start_line, start_side, line, original_line, side, original_position, position, subject_type)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28)
+INSERT INTO public.github_pr_review_comments (repo_id, url, pull_request_review_id, pull_request_number, id, diff_hunk, path, commit_id, original_commit_id, user_login, user_id, user_avatar_url, user_url, created_at, updated_at, author_association, body, reactions, start_line, original_start_line, start_side, line, original_line, side, original_position, position, subject_type)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27)
     `, [
         repoID,
         comment.url,
         comment.pull_request_review_id,
         comment.pull_request_url.split("/").pop(),
         comment.id,
-        comment.node_id,
         comment.diff_hunk,
         comment.path,
         comment.commit_id,

--- a/syncs/github-pull-request-review-comments/main.ts
+++ b/syncs/github-pull-request-review-comments/main.ts
@@ -1,0 +1,111 @@
+//  _ __ ___   ___ _ __ __ _  ___ ___| |_ __ _| |_
+// | '_ ` _ \ / _ | '__/ _` |/ _ / __| __/ _` | __|
+// | | | | | |  __| | | (_| |  __\__ | || (_| | |_
+// |_| |_| |_|\___|_|  \__, |\___|___/\__\__,_|\__|
+//                     |___/
+//
+// This syncer uses the GitHub API to sync PR review comments for the given repository.
+//
+// @author: Patrick DeVivo (patrick@mergestat.com)
+
+import { Octokit } from "https://esm.sh/v124/octokit@2.0.14";
+import { throttling } from "https://esm.sh/@octokit/plugin-throttling";
+import { Client } from "https://deno.land/x/postgres@v0.17.0/mod.ts";
+
+const repoID = Deno.env.get("MERGESTAT_REPO_ID")
+const repoURL = new URL(Deno.env.get("MERGESTAT_REPO_URL") || "");
+const owner = repoURL.pathname.split("/")[1];
+const repo = repoURL.pathname.split("/")[2];
+
+const OctokitWithThrottling = Octokit.plugin(throttling);
+const octokit = new OctokitWithThrottling({
+    auth: Deno.env.get("MERGESTAT_AUTH_TOKEN"),
+    throttle: {
+        onRateLimit: (retryAfter, options, octokit, retryCount) => {
+          octokit.log.warn(
+            `Request quota exhausted for request ${options.method} ${options.url}`
+          );
+    
+          if (retryCount < 1) {
+            // only retries once
+            octokit.log.info(`Retrying after ${retryAfter} seconds!`);
+            return true;
+          }
+        },
+        onSecondaryRateLimit: (retryAfter, options, octokit) => {
+          // does not retry, only logs a warning
+          octokit.log.warn(
+            `SecondaryRateLimit detected for request ${options.method} ${options.url}`
+          );
+        },
+      },
+});
+const commentsBuffer = [];
+
+const iterator = octokit.paginate.iterator(`GET /repos/${owner}/${repo}/pulls/comments`, {
+    headers: {
+        'X-GitHub-Api-Version': '2022-11-28'
+    },
+    owner, repo
+});
+  
+for await (const { data: comments } of iterator) {
+    console.log(`fetched page of PR review comments for: ${owner}/${repo} (${comments.length} review comments)`)
+    for (const alert of comments) {
+        commentsBuffer.push(alert)
+    }
+}
+
+console.log(`fetched ${commentsBuffer.length} PR review comments for: ${owner}/${repo}`)
+
+const schemaSQL = await Deno.readTextFile("./schema.sql");
+const client = new Client(Deno.env.get("MERGESTAT_POSTGRES_URL"));
+await client.connect();
+
+const tx = await client.createTransaction("syncs/github-pr-review-comments");
+await tx.begin()
+
+await tx.queryArray(schemaSQL);
+await tx.queryArray(`DELETE FROM public.github_pr_review_comments WHERE repo_id = $1;`, [repoID]);
+for await (const comment of commentsBuffer) {
+    await tx.queryArray(`
+INSERT INTO public.github_pr_review_comments (repo_id, url, pull_request_review_id, pull_request_number, id, node_id, diff_hunk, path, commit_id, original_commit_id, user_login, user_id, user_avatar_url, user_url, created_at, updated_at, author_association, body, reactions, start_line, original_start_line, start_side, line, original_line, side, original_position, position, subject_type)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28)
+    `, [
+        repoID,
+        comment.url,
+        comment.pull_request_review_id,
+        comment.pull_request_url.split("/").pop(),
+        comment.id,
+        comment.node_id,
+        comment.diff_hunk,
+        comment.path,
+        comment.commit_id,
+        comment.original_commit_id,
+        comment.user?.login,
+        comment.user?.id,
+        comment.user?.avatar_url,
+        comment.user?.url,
+        comment.created_at,
+        comment.updated_at,
+        comment.author_association,
+        comment.body,
+        JSON.stringify(comment.reactions),
+        comment.start_line,
+        comment.original_start_line,
+        comment.start_side,
+        comment.line,
+        comment.original_line,
+        comment.side,
+        comment.original_position,
+        comment.position,
+        comment.subject_type
+    ]);
+}
+await tx.commit();
+
+await client.end();
+
+console.log(`synced ${commentsBuffer.length} PR review comments for: ${owner}/${repo} (repo_id: ${repoID})`)
+
+Deno.exit(0)

--- a/syncs/github-pull-request-review-comments/schema.sql
+++ b/syncs/github-pull-request-review-comments/schema.sql
@@ -4,7 +4,6 @@ CREATE TABLE IF NOT EXISTS github_pr_review_comments (
     pull_request_review_id bigint,
     pull_request_number integer,
     id bigint,
-    node_id text,
     diff_hunk text,
     path text,
     commit_id text,
@@ -39,7 +38,6 @@ COMMENT ON COLUMN github_pr_review_comments.url IS 'URL to the issue comment';
 COMMENT ON COLUMN github_pr_review_comments.pull_request_review_id IS 'id of the pull request review';
 COMMENT ON COLUMN github_pr_review_comments.pull_request_number IS 'pull request number';
 COMMENT ON COLUMN github_pr_review_comments.id IS 'id of the review comment';
-COMMENT ON COLUMN github_pr_review_comments.node_id IS 'node id of the review comment';
 COMMENT ON COLUMN github_pr_review_comments.diff_hunk IS 'diff hunk';
 COMMENT ON COLUMN github_pr_review_comments.path IS 'file path';
 COMMENT ON COLUMN github_pr_review_comments.commit_id IS 'commit id';

--- a/syncs/github-pull-request-review-comments/schema.sql
+++ b/syncs/github-pull-request-review-comments/schema.sql
@@ -1,0 +1,67 @@
+CREATE TABLE IF NOT EXISTS github_pr_review_comments (
+    repo_id uuid REFERENCES repos(id) ON DELETE CASCADE ON UPDATE RESTRICT,
+    url text,
+    pull_request_review_id bigint,
+    pull_request_number integer,
+    id bigint,
+    node_id text,
+    diff_hunk text,
+    path text,
+    commit_id text,
+    original_commit_id text,
+    user_login text,
+    user_id integer,
+    user_avatar_url text,
+    user_url text,
+    created_at timestamp with time zone,
+    updated_at timestamp with time zone,
+    author_association text,
+    body text,
+    reactions jsonb,
+    start_line integer,
+    original_start_line integer,
+    start_side text,
+    line integer,
+    original_line integer,
+    side text,
+    original_position integer,
+    position integer,
+    subject_type text,
+
+    _mergestat_synced_at timestamp with time zone NOT NULL DEFAULT now(),
+    CONSTRAINT github_pr_review_comments_pkey PRIMARY KEY (repo_id, id)
+
+);
+
+COMMENT ON TABLE github_pr_review_comments IS 'issue comments of a GitHub repo';
+COMMENT ON COLUMN github_pr_review_comments.repo_id IS 'foreign key for public.repos.id';
+COMMENT ON COLUMN github_pr_review_comments.url IS 'URL to the issue comment';
+COMMENT ON COLUMN github_pr_review_comments.pull_request_review_id IS 'id of the pull request review';
+COMMENT ON COLUMN github_pr_review_comments.pull_request_number IS 'pull request number';
+COMMENT ON COLUMN github_pr_review_comments.id IS 'id of the review comment';
+COMMENT ON COLUMN github_pr_review_comments.node_id IS 'node id of the review comment';
+COMMENT ON COLUMN github_pr_review_comments.diff_hunk IS 'diff hunk';
+COMMENT ON COLUMN github_pr_review_comments.path IS 'file path';
+COMMENT ON COLUMN github_pr_review_comments.commit_id IS 'commit id';
+COMMENT ON COLUMN github_pr_review_comments.original_commit_id IS 'original commit id';
+COMMENT ON COLUMN github_pr_review_comments.user_login IS 'login of the user who created the review comment';
+COMMENT ON COLUMN github_pr_review_comments.user_id IS 'id of the user who created the review comment';
+COMMENT ON COLUMN github_pr_review_comments.user_avatar_url IS 'avatar URL of the user who created the review comment';
+COMMENT ON COLUMN github_pr_review_comments.user_url IS 'URL to the user who created the review comment';
+COMMENT ON COLUMN github_pr_review_comments.created_at IS 'timestamp when the review comment was created';
+COMMENT ON COLUMN github_pr_review_comments.updated_at IS 'timestamp when the review comment was updated';
+COMMENT ON COLUMN github_pr_review_comments.author_association IS 'author association of the user who created the review comment';
+COMMENT ON COLUMN github_pr_review_comments.body IS 'body of the review comment';
+COMMENT ON COLUMN github_pr_review_comments.reactions IS 'reactions of the review comment';
+COMMENT ON COLUMN github_pr_review_comments.start_line IS 'start line';
+COMMENT ON COLUMN github_pr_review_comments.original_start_line IS 'original start line';
+COMMENT ON COLUMN github_pr_review_comments.start_side IS 'start side';
+COMMENT ON COLUMN github_pr_review_comments.line IS 'line';
+COMMENT ON COLUMN github_pr_review_comments.original_line IS 'original line';
+COMMENT ON COLUMN github_pr_review_comments.side IS 'side';
+COMMENT ON COLUMN github_pr_review_comments.original_position IS 'original position';
+COMMENT ON COLUMN github_pr_review_comments.position IS 'position';
+COMMENT ON COLUMN github_pr_review_comments.subject_type IS 'subject type';
+COMMENT ON COLUMN github_pr_review_comments._mergestat_synced_at IS 'timestamp when record was synced into the MergeStat database';
+
+CREATE INDEX IF NOT EXISTS idx_github_pr_review_comments_repo_id_fkey ON github_pr_review_comments(repo_id uuid_ops);


### PR DESCRIPTION
Sync for GitHub PR review comments. See here: https://docs.github.com/en/rest/pulls/comments?apiVersion=2022-11-28#list-review-comments-in-a-repository