### PR TITLE
fix: remove all use of `node_id` as a column

### DIFF
--- a/syncs/github-issue-comments/main.ts
+++ b/syncs/github-issue-comments/main.ts
@@ -69,9 +69,9 @@ await tx.queryArray(schemaSQL);
 await tx.queryArray(`DELETE FROM public.github_issue_comments WHERE repo_id = $1;`, [repoID]);
 for await (const comment of commentsBuffer) {
     await tx.queryArray(`
-INSERT INTO public.github_issue_comments (repo_id, id, node_id, issue_number, url, user_login, user_id, user_type, user_avatar_url, user_url, created_at, updated_at, author_association, body, reactions)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
-    `, [repoID, comment.id, comment.node_id, comment.issue_url.split("/").pop(), comment.url, comment.user?.login, comment.user?.id, comment.user?.type, comment.user?.avatar_url, comment.user?.url, comment.created_at, comment.updated_at, comment.author_association, comment.body, JSON.stringify(comment.reactions)]);
+INSERT INTO public.github_issue_comments (repo_id, id, issue_number, url, user_login, user_id, user_type, user_avatar_url, user_url, created_at, updated_at, author_association, body, reactions)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+    `, [repoID, comment.id, comment.issue_url.split("/").pop(), comment.url, comment.user?.login, comment.user?.id, comment.user?.type, comment.user?.avatar_url, comment.user?.url, comment.created_at, comment.updated_at, comment.author_association, comment.body, JSON.stringify(comment.reactions)]);
 }
 await tx.commit();
 

--- a/syncs/github-issue-comments/schema.sql
+++ b/syncs/github-issue-comments/schema.sql
@@ -1,7 +1,6 @@
 CREATE TABLE IF NOT EXISTS github_issue_comments (
     repo_id uuid REFERENCES repos(id) ON DELETE CASCADE ON UPDATE RESTRICT,
     id bigint,
-    node_id text,
     issue_number integer,
     url text,
     user_login text,
@@ -23,7 +22,6 @@ CREATE TABLE IF NOT EXISTS github_issue_comments (
 COMMENT ON TABLE github_issue_comments IS 'issue comments of a GitHub repo';
 COMMENT ON COLUMN github_issue_comments.repo_id IS 'foreign key for public.repos.id';
 COMMENT ON COLUMN github_issue_comments.id IS 'id of the issue comment';
-COMMENT ON COLUMN github_issue_comments.node_id IS 'node id of the issue comment';
 COMMENT ON COLUMN github_issue_comments.issue_number IS 'issue number';
 COMMENT ON COLUMN github_issue_comments.url IS 'URL to the issue comment';
 COMMENT ON COLUMN github_issue_comments.user_login IS 'login of the user who created the issue comment';

--- a/syncs/github-issue-events/main.ts
+++ b/syncs/github-issue-events/main.ts
@@ -70,9 +70,9 @@ await tx.queryArray(schemaSQL);
 await tx.queryArray(`DELETE FROM public.github_issue_events WHERE repo_id = $1;`, [repoID]);
 for await (const event of eventsBuffer) {
     await tx.queryArray(`
-INSERT INTO public.github_issue_events (repo_id, id, node_id, issue_number, url, actor_login, actor_id, actor_avatar_url, actor_url, event, commit_id, commit_url, created_at)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
-    `, [repoID, event.id, event.node_id, event.issue?.number, event.url, event.actor?.login, event.actor?.id, event.actor?.avatar_url, event.actor?.url, event.event, event.commit_id, event.commit_url, event.created_at]);
+INSERT INTO public.github_issue_events (repo_id, id, issue_number, url, actor_login, actor_id, actor_avatar_url, actor_url, event, commit_id, commit_url, created_at)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+    `, [repoID, event.id, event.issue?.number, event.url, event.actor?.login, event.actor?.id, event.actor?.avatar_url, event.actor?.url, event.event, event.commit_id, event.commit_url, event.created_at]);
 }
 await tx.commit();
 

--- a/syncs/github-issue-events/schema.sql
+++ b/syncs/github-issue-events/schema.sql
@@ -1,7 +1,6 @@
 CREATE TABLE IF NOT EXISTS github_issue_events (
     repo_id uuid REFERENCES repos(id) ON DELETE CASCADE ON UPDATE RESTRICT,
     id bigint,
-    node_id text,
     issue_number integer,
     url text,
     actor_login text,
@@ -21,7 +20,6 @@ CREATE TABLE IF NOT EXISTS github_issue_events (
 COMMENT ON TABLE github_issue_events IS 'issue events of a GitHub repo';
 COMMENT ON COLUMN github_issue_events.repo_id IS 'foreign key for public.repos.id';
 COMMENT ON COLUMN github_issue_events.id IS 'id of the issue event';
-COMMENT ON COLUMN github_issue_events.node_id IS 'node id of the issue event';
 COMMENT ON COLUMN github_issue_events.issue_number IS 'issue number';
 COMMENT ON COLUMN github_issue_events.url IS 'URL to the issue event';
 COMMENT ON COLUMN github_issue_events.actor_login IS 'login of the issue event actor';

--- a/syncs/github-releases/main.ts
+++ b/syncs/github-releases/main.ts
@@ -46,9 +46,9 @@ await tx.queryArray(schemaSQL);
 await tx.queryArray(`DELETE FROM public.github_releases WHERE repo_id = $1;`, [repoID]);
 for await (const release of releasesBuffer) {
     await tx.queryArray(`
-INSERT INTO public.github_releases (repo_id, url, assets_url, upload_url, html_url, database_id, author_login, author_url, author_avatar_url, node_id, tag_name, target_commitish, name, draft, prerelease, created_at, published_at, assets, tarball_url, zipball_url, body, mentions_count)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22)
-    `, [repoID, release.url, release.assets_url, release.upload_url, release.html_url, release.id, release.author.login, release.author.url, release.author.avatar_url, release.node_id, release.tag_name, release.target_commitish, release.name, release.draft, release.prerelease, release.created_at, release.published_at, JSON.stringify(release.assets), release.tarball_url, release.zipball_url, release.body, release.mentions_count]);
+INSERT INTO public.github_releases (repo_id, url, assets_url, upload_url, html_url, database_id, author_login, author_url, author_avatar_url, tag_name, target_commitish, name, draft, prerelease, created_at, published_at, assets, tarball_url, zipball_url, body, mentions_count)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21)
+    `, [repoID, release.url, release.assets_url, release.upload_url, release.html_url, release.id, release.author.login, release.author.url, release.author.avatar_url, release.tag_name, release.target_commitish, release.name, release.draft, release.prerelease, release.created_at, release.published_at, JSON.stringify(release.assets), release.tarball_url, release.zipball_url, release.body, release.mentions_count]);
 }
 
 await tx.commit();

--- a/syncs/github-releases/schema.sql
+++ b/syncs/github-releases/schema.sql
@@ -10,7 +10,6 @@ CREATE TABLE IF NOT EXISTS public.github_releases (
     author_login text,
     author_url text,
     author_avatar_url text,
-    node_id text,
     tag_name text,
     target_commitish text,
     name text,
@@ -37,7 +36,6 @@ COMMENT ON COLUMN github_releases.database_id IS 'GitHub database_id of the rele
 COMMENT ON COLUMN github_releases.author_login IS 'login of the author of the release';
 COMMENT ON COLUMN github_releases.author_url IS 'URL to the profile of the author of the release';
 COMMENT ON COLUMN github_releases.author_avatar_url IS 'URL to the avatar of the author of the release';
-COMMENT ON COLUMN github_releases.node_id IS 'GitHub node id of the release';
 COMMENT ON COLUMN github_releases.tag_name IS 'tag name of the release';
 COMMENT ON COLUMN github_releases.target_commitish IS 'specifies the commitish value that determines where the release is created from';
 COMMENT ON COLUMN github_releases.name IS 'name of the release';


### PR DESCRIPTION
This appears to conflict with Postgraphile unfortunately, causing downstream startup issues in `mergestat/mergestat`