### PR TITLE
Enable back arm64 images in main

### DIFF
--- a/.github/workflows/publish-container-images.yml
+++ b/.github/workflows/publish-container-images.yml
@@ -75,7 +75,7 @@ jobs:
         name: Build and push
         uses: docker/build-push-action@v3
         with:
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           context: ./syncs/${{ matrix.syncs }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
arm64 Docker images are not being published anymore from main. This means there are no "latest" images for arm64 architectures. The only available ones are the ones being published from the branches.

This change enable arm64 images back again in main.